### PR TITLE
README should call ngrok to start ngrok, not npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ bundle exec rackup
 Use `npm` to install `ngrok` to host on a non-local URL:
 ```
 npm install ngrok -g
-npm http 9292
+ngrok http 9292
 ```


### PR DESCRIPTION
Whoops. Gotta use the correct command.